### PR TITLE
hidl: fingerprint: Do not override nonvirtual member functions

### DIFF
--- a/hidl/fingerprint/BiometricsFingerprint.h
+++ b/hidl/fingerprint/BiometricsFingerprint.h
@@ -71,8 +71,8 @@ public:
     Return<bool> isUdfps(uint32_t sensorID) override;
     Return<void> onFingerDown(uint32_t x, uint32_t y, float minor, float major) override;
     Return<void> onFingerUp() override;
-    Return<void> onShowUdfpsOverlay() override;
-    Return<void> onHideUdfpsOverlay() override;
+    Return<void> onShowUdfpsOverlay();
+    Return<void> onHideUdfpsOverlay();
 
 private:
     static const char* getModuleId();


### PR DESCRIPTION
 Fix build error:
hardware/oneplus/hidl/fingerprint/BiometricsFingerprint.h:74:39: error: only virtual member functions can be marked 'override'
    Return<void> onShowUdfpsOverlay() override;
                                      ^~~~~~~~
hardware/oneplus/hidl/fingerprint/BiometricsFingerprint.h:75:39: error: only virtual member functions can be marked 'override'
    Return<void> onHideUdfpsOverlay() override;
                                      ^~~~~~~~
2 errors generated.

Change-Id: I75b0283d550fd21423f429932d9385d20c3992ba